### PR TITLE
[W-17275164] Update EOL support link

### DIFF
--- a/modules/ROOT/partials/eol-banner.adoc
+++ b/modules/ROOT/partials/eol-banner.adoc
@@ -1,4 +1,7 @@
-// Sample banner definition
+// The EOL banners are currently getting pulled from the location below:
+// https://github.com/mulesoft/docs-site-ui/commits/main/src/partials/notice-banner
+//
+// This is a sample definition for custom EOL banners
 // Feature Scheduled for EOL - BANNER
 // tag::eolFeatureScheduled[]
 // [.notice-banner]

--- a/modules/ROOT/partials/eol-note.adoc
+++ b/modules/ROOT/partials/eol-note.adoc
@@ -1,6 +1,3 @@
-// Important: The EOL banners are currently getting pulled from the location below and not from this file:
-// https://github.com/mulesoft/docs-site-ui/commits/main/src/partials/notice-banner
-//
 // Product Scheduled for EOL - NOTE for RNs - multiple releases/file
 // include::reuse::partial$eol-note.adoc[tag=eolScheduled]
 // tag::eolScheduled[]


### PR DESCRIPTION
Replaced all references to the old support link on help.mulesoft.com with the new Salesforce support policy. (These are for inline notes, not for the banners.)

Also, updated the EOL banner links in this related PR:
https://github.com/mulesoft/docs-site-ui/pull/829